### PR TITLE
Fix Área-Modalidade

### DIFF
--- a/app/Http/Controllers/EventoController.php
+++ b/app/Http/Controllers/EventoController.php
@@ -317,7 +317,7 @@ class EventoController extends Controller
         $trabalhosId = Trabalho::whereIn('areaId', $areasId)->select('id')->get();
         $revisores = Revisor::where('eventoId', $evento->id)->get();
         $modalidades = Modalidade::all();
-        $areaModalidades = AreaModalidade::whereIn('id', $areasId)->get();
+        $areaModalidades = AreaModalidade::whereIn('areaId', $areasId)->get();        
         $trabalhos = Trabalho::whereIn('areaId', $areasId)->orderBy('id')->get();
         $trabalhosEnviados = Trabalho::whereIn('areaId', $areasId)->count();
         $trabalhosPendentes = Trabalho::whereIn('areaId', $areasId)->where('avaliado', 'processando')->count();

--- a/app/Http/Controllers/TrabalhoController.php
+++ b/app/Http/Controllers/TrabalhoController.php
@@ -33,8 +33,8 @@ class TrabalhoController extends Controller
         $areas = Area::where('eventoId', $evento->id)->get();
         $areasId = Area::where('eventoId', $evento->id)->select('id')->get();
         $revisores = Revisor::where('eventoId', $evento->id)->get();
-        $modalidades = Modalidade::all();
-        $areaModalidades = AreaModalidade::whereIn('id', $areasId)->get();
+        $modalidades = Modalidade::all();        
+        $areaModalidades = AreaModalidade::whereIn('areaId', $areasId)->get();        
         $areasEnomes = Area::wherein('id', $areasId)->get();
         $modalidadesIDeNome = [];
         foreach ($areaModalidades as $key) {

--- a/resources/views/coordenador/detalhesEvento.blade.php
+++ b/resources/views/coordenador/detalhesEvento.blade.php
@@ -383,6 +383,7 @@
             <tr>
               <th scope="col">ID</th>
               <th scope="col">Área</th>
+              <th scope="col">Modalidade</th>
               <th scope="col">Revisores</th>
               <th scope="col" style="text-align:center">Baixar</th>
               <th scope="col" style="text-align:center">Visualizar</th>
@@ -395,6 +396,7 @@
             <tr>
               <td>{{$trabalho->id}}</td>
               <td>{{$trabalho->area->nome}}</td>
+              <td>{{$trabalho->modalidade->nome}}</td>
               <td>
                 @foreach($trabalho->atribuicao as $atribuicao)
                 {{$atribuicao->revisor->user->email}},


### PR DESCRIPTION
Ao submeter um trabalho, não era possível visualizar todas as modalidades de uma área.
Também não era possível adicionar mais de uma modalidade à mesma área.

- Adição da coluna modalidade na view de listar trabalhos (perfil de coordenador)
- Conserto de erro na busca em AreaModalidade: '**id**' substituída por '**areaId**'